### PR TITLE
ibdev2netdev: Support dual port RoCE having single IB device

### DIFF
--- a/ofed_scripts/ibdev2netdev
+++ b/ofed_scripts/ibdev2netdev
@@ -1,4 +1,30 @@
 #! /bin/bash
+#
+# Copyright (c) 2017 Mellanox Technologies. All rights reserved.
+#
+# This Software is licensed under one of the following licenses:
+#
+# 1) under the terms of the "Common Public License 1.0" a copy of which is
+#    available from the Open Source Initiative, see
+#    http://www.opensource.org/licenses/cpl.php.
+#
+# 2) under the terms of the "The BSD License" a copy of which is
+#    available from the Open Source Initiative, see
+#    http://www.opensource.org/licenses/bsd-license.php.
+#
+# 3) under the terms of the "GNU General Public License (GPL) Version 2" a
+#    copy of which is available from the Open Source Initiative, see
+#    http://www.opensource.org/licenses/gpl-license.php.
+#
+# Licensee has the right to choose one of the above licenses.
+#
+# Redistributions of source code must retain the above copyright
+# notice and one of the license notices.
+#
+# Redistributions in binary form must reproduce both the above copyright
+# notice, one of the license notices in the documentation
+# and/or other materials provided with the distribution.
+#
 
 usage()
 {
@@ -64,91 +90,107 @@ for d in $devs; do
 	fi
 done
 
+function print_verbose_info()
+{
+	d=$1
+	port=$2
+	eth=$3
+	link_state=$4
+	filepath_portstate=/sys/class/infiniband/$d/ports/$port/state
+	filepath_deviceid=/sys/class/infiniband/$d/device/device
+	filepath_fwver=/sys/class/infiniband/$d/fw_ver
+	filepath_vpd=/sys/class/infiniband/$d/device/vpd
+
+	# read port state
+	if [ -f $filepath_portstate ]; then
+		ibstate=$(printf "%-6s" $(cat $filepath_portstate | awk '{print $2}'))
+	else
+		ibstate="NA"
+	fi
+
+	# read device
+	if [ -f $filepath_deviceid ]; then
+		devid=$(printf "MT%d" $(cat $filepath_deviceid))
+	else
+		devid="NA"
+	fi
+
+	# read FW version
+	if [ -f $filepath_fwver ]; then
+		fwver=$(cat $filepath_fwver)
+	else
+		fwver="NA"
+	fi
+
+	# read device description and part ID from the VPD
+	if [ -f $filepath_vpd ]; then
+		tmp=$IFS
+		IFS=":"
+		vpd_content=`cat $filepath_vpd`
+		devdesc=$(printf "%-15s" $(echo $vpd_content | strings | head -1))
+		partid=$(printf "%-11s" $(echo $vpd_content | strings | head -4 | tail -1 | awk '{print $1}'))
+		IFS=$tmp
+	else
+		devdesc=""
+		partid="NA"
+	fi
+	echo "$x $d ($devid - $partid) $devdesc fw $fwver port $port ($ibstate) ==> $eth ($link_state)"
+}
+
+function get_link_state()
+{
+	eth=$1
+	filepath_devid=/sys/class/net/$eth/dev_id
+	if [ -f $filepath_devid ]; then
+		filepath_carrier=/sys/class/net/$eth/carrier
+		if [ -f $filepath_carrier ]; then
+			link_state=$(cat $filepath_carrier 2> /dev/null)
+        	        if (( link_state == 1 )); then
+        	                link_state="Up"
+        	        else
+        	                link_state="Down"
+		        fi
+		else
+			link_state="NA"
+		fi
+	fi
+	echo -n $link_state
+}
+
 if [ "x$oldstyle" == "xn" ]; then
 	for d in $ibdevs; do
-		ibrsc=$(cat /sys/class/infiniband/$d/device/resource)
-		eths=$(ls /sys/class/net/)
-		for eth in $eths; do
-			filepath_resource=/sys/class/net/$eth/device/resource
+		ports=$(ls /sys/class/infiniband/$d/ports/)
+		for port in $ports; do
+			#Honor ndev given by the kernel in the gid table for RoCE, soft RoCE
+			#if kernel doesn't expose it (for IB), try the different method of
+			#resource match.
+			ethdev=$(cat /sys/class/infiniband/$d/ports/$port/gid_attrs/ndevs/0 2> /dev/null)
+			if [ "$ethdev" == "" ]; then
+				ibrsc=$(cat /sys/class/infiniband/$d/device/resource)
+				eths=$(ls /sys/class/net/)
+				for eth in $eths; do
+					filepath_resource=/sys/class/net/$eth/device/resource
 
-			if [ -f $filepath_resource ]; then
-				ethrsc=$(cat $filepath_resource)
-				if [ "x$ethrsc" == "x$ibrsc" ]; then
-					filepath_devid=/sys/class/net/$eth/dev_id
-					filepath_devport=/sys/class/net/$eth/dev_port
-					if [ -f $filepath_devid ]; then
-						port1=0
-						if [ -f $filepath_devport ]; then
-							port1=$(cat $filepath_devport)
-							port1=$(printf "%d" $port1)
-						fi
-
-						port=$(cat $filepath_devid)
-						port=$(printf "%d" $port)
-						if [ $port1 -gt $port ]; then
-							port=$port1
-						fi
-
-						port=$(( port + 1 ))
-
-						filepath_carrier=/sys/class/net/$eth/carrier
-
-						if [ -f $filepath_carrier ]; then
-							link_state=$(cat $filepath_carrier 2> /dev/null)
-        	                                        if (( link_state == 1 )); then
-                	                                        link_state="Up"
-                        	                        else
-                                	                        link_state="Down"
-                                        	        fi
-						else
-							link_state="NA"
-						fi
-
-						x=$(find_pdev $d)
-						if [ "$1" == "-v" ]; then
-							filepath_portstate=/sys/class/infiniband/$d/ports/$port/state
-							filepath_deviceid=/sys/class/infiniband/$d/device/device
-							filepath_fwver=/sys/class/infiniband/$d/fw_ver
-							filepath_vpd=/sys/class/infiniband/$d/device/vpd
-
-							# read port state
-							if [ -f $filepath_portstate ]; then
-								ibstate=$(printf "%-6s" $(cat $filepath_portstate | awk '{print $2}'))
-							else
-								ibstate="NA"
-							fi
-
-							# read device
-							if [ -f $filepath_deviceid ]; then
-								devid=$(printf "MT%d" $(cat $filepath_deviceid))
-							else
-								devid="NA"
-							fi
-
-							# read FW version
-							if [ -f $filepath_fwver ]; then
-								fwver=$(cat $filepath_fwver)
-							else
-								fwver="NA"
-							fi
-
-							# read device description and part ID from the VPD
-							if [ -f $filepath_vpd ]; then
-								tmp=$IFS
-								IFS=":"
-								vpd_content=`cat $filepath_vpd`
-								devdesc=$(printf "%-15s" $(echo $vpd_content | strings | head -1))
-								partid=$(printf "%-11s" $(echo $vpd_content | strings | head -4 | tail -1 | awk '{print $1}'))
-								IFS=$tmp
-							else
-								devdesc=""
-								partid="NA"
-							fi
-							echo "$x $d ($devid - $partid) $devdesc fw $fwver port $port ($ibstate) ==> $eth ($link_state)"
-						else
-							echo "$d port $port ==> $eth ($link_state)"
+					if [ -f $filepath_resource ]; then
+						ethrsc=$(cat $filepath_resource)
+						if [ "x$ethrsc" == "x$ibrsc" ]; then
+								link_state=$(get_link_state $eth)
+								x=$(find_pdev $d)
+								if [ "$1" == "-v" ]; then
+									print_verbose_info $d $port $eth $link_state
+								else
+									echo "$d port $port ==> $eth ($link_state)"
+								fi
+								break
 						fi
 					fi
+				done
+			else
+				link_state=$(get_link_state $ethdev)
+				if [ "$1" == "-v" ]; then
+					print_verbose_info $d $port $ethdev $link_state
+				else
+					echo "$d port $port ==> $ethdev ($link_state)"
 				fi
 			fi
 		done


### PR DESCRIPTION
With recent support of IB(RoCE) device with two pci functions, each
having netdevice, cannot work with existing matching functionality, as
resources doesn't match.
This is different mode than ConnectX3 RoCE where there is only one PCIe
device for two netdevice who has same resource.

Therefore to simplify it for RoCE, use netdevice of the gid[0] entry to
map ibdevice to netdevice.
This scheme also allows to show mapping of one ibdevice to multiple
netdevice where non gid[0] will be considered in future.

While to avoid code duplication and to have better readability, existing
routines are made as as routines to reuse for gid based prints and
traditional search method.

Orabug: 26941726
MlnxSF: 00395128
Upstream_status: ignore
Signed-off-by: Parav Pandit <parav@mellanox.com>