### PR TITLE
ibdev2netdev: Fix Support for ConnectX3 InfiniBand

### DIFF
--- a/ofed_scripts/ibdev2netdev
+++ b/ofed_scripts/ibdev2netdev
@@ -157,15 +157,58 @@ function get_link_state()
 	echo -n $link_state
 }
 
+function find_matching_ndev_for_gid()
+{
+	gid=$1
+	gid_without_prefix=${gid#"fe80:0000:0000:0000:"}
+	gid_without_colon=${gid_without_prefix//:}
+
+	ip_link_output=$(ip link show)
+	IFS=$'\n' read -rd '' -a array <<<"$ip_link_output"
+
+	for index in "${!array[@]}"
+	do
+		#search for infiniband address
+		if [[ ${array[index]} =~ .*infiniband.* ]]; then
+			ib_addr=${array[index]}
+			#retain string after link/infiniband
+			ib_addr=${ib_addr##*infiniband}
+			#retain string before brd
+			ib_addr=${ib_addr%brd*}
+			#extract 8 bytes of hw address
+			ib_addr=${ib_addr:37:25}
+			#remove : from the address, have only alphanumeric
+			ib_addr=${ib_addr//:}
+
+			ib_ndev_name=${array[index-1]}
+			#retain string before :
+			ib_ndev_name=${ib_ndev_name%:*}
+			#retain string after :
+			ib_ndev_name=${ib_ndev_name#*:}
+
+			if [ $gid_without_colon == $ib_addr ]; then
+				echo -n $ib_ndev_name
+				break
+			fi
+		fi
+	done
+}
+
 if [ "x$oldstyle" == "xn" ]; then
 	for d in $ibdevs; do
 		ports=$(ls /sys/class/infiniband/$d/ports/)
 		for port in $ports; do
-			#Honor ndev given by the kernel in the gid table for RoCE, soft RoCE
-			#if kernel doesn't expose it (for IB), try the different method of
-			#resource match.
-			ethdev=$(cat /sys/class/infiniband/$d/ports/$port/gid_attrs/ndevs/0 2> /dev/null)
-			if [ "$ethdev" == "" ]; then
+			link_layer=$(cat /sys/class/infiniband/$d/ports/$port/link_layer)
+			if [ "x$link_layer" == "xInfiniBand" ]; then
+				gid=$(cat /sys/class/infiniband/$d/ports/$port/gids/0)
+				ethdev=$(find_matching_ndev_for_gid $gid)
+			else
+				ethdev=$(cat /sys/class/infiniband/$d/ports/$port/gid_attrs/ndevs/0 2> /dev/null)
+				#Honor ndev given by the kernel in the gid table for RoCE, soft RoCE
+				#if kernel doesn't expose it (for IB), try the different method of
+				#resource match.
+			fi
+			if [[ -z $ethdev ]]; then
 				ibrsc=$(cat /sys/class/infiniband/$d/device/resource)
 				eths=$(ls /sys/class/net/)
 				for eth in $eths; do
@@ -252,7 +295,7 @@ for ifc in $ifcs; do
 		guid=$(cat /sys/class/net/$ifc/address | cut -b 37- | sed -e 's/://g')
 		find_guid $guid $ifc
 	elif (( len == 6)); then
-		mac=$(cat /sys/class/net/$ifc/address | sed -e 's/://g')	
+		mac=$(cat /sys/class/net/$ifc/address | sed -e 's/://g')
 		find_mac $mac $ifc
 	fi
 done


### PR DESCRIPTION
For IB link layer devices, perform lookup of IB device to netdevice
mapping based on the GID address of ib device  and HW address of
IPoIB netdevice.

Orabug: 26941726
MlnxSF: 00395128
Upstream_status: ignore

Signed-off-by: Parav Pandit <parav@mellanox.com>